### PR TITLE
fix: make escape backticks

### DIFF
--- a/scripts/sync/index.js
+++ b/scripts/sync/index.js
@@ -23,9 +23,9 @@ fs.readFile(syncFilePath, (err, file) => {
         '',
         '---',
         '',
-        '```diff',
+        '````diff',
         diff,
-        '```',
+        '````',
       ].join('\n'),
     }));
 });


### PR DESCRIPTION
### 어떤 문제가 있었나요?

- Markdown 내 Backtics(`` ` ``) 사용으로 인한 렌더 에러

### 어떤 부분을 수정했나요?

- Backtics 구분자 추가

### 그 외

- 
