### PR TITLE
docs(ko): fix typo index.md

### DIFF
--- a/config/index.md
+++ b/config/index.md
@@ -159,7 +159,7 @@ export default defineConfig(({ command, mode }) => {
 
   - [esbuild](https://esbuild.github.io/api/#define)와 일관성을 유지하기 위해, 표현식은 JSON 객체(null, boolean, number, string, array, 또는 object)이거나 단일 식별자여야 합니다.
 
-  - 매치되는 부분이 단어 경계 (`\b`)로 둘러쌓인 경우에만 대체가 수행됩니다.
+  - 매치되는 부분이 단어 경계 (`\b`)로 둘러싸인 경우에만 대체가 수행됩니다.
 
   ::: warning
   이것은 아무런 구문 분석 없이 간단한 텍스트 대체로 구현되므로, 상수에만 `define` 을 사용하는 것을 추천합니다.


### PR DESCRIPTION
### 어떤 문제가 있었나요?

- 문서에 한글 맞춤법에 어긋난 부분을 올바르게 수정

### 어떤 부분을 수정했나요?

-  둘러쌓인(X) -> 둘러싸인(O)

### 그 외

- 
