### PR TITLE
fix(ko): fix typo in config/index.md

### DIFF
--- a/config/index.md
+++ b/config/index.md
@@ -179,7 +179,7 @@ export default defineConfig(({ command, mode }) => {
   예제:
 
   ```ts
-  // vite-end.d.ts
+  // vite-env.d.ts
   declare const __APP_VERSION__: string
   ```
 


### PR DESCRIPTION
### 어떤 문제가 있었나요?

- 설정 > 공용옵션 > define의 예제코드에서 파일명이 `vite-end.d.ts`로 되어있습니다.
![vite-config-define-kr](https://user-images.githubusercontent.com/71176945/168754095-ffd225a0-5403-40a0-8e17-ed0d30446b40.png)


### 어떤 부분을 수정했나요?

- 설정 > 공용옵션 > define 예제코드의 파일명 `vite-end.d.ts` -> `vite-env.d.ts`

