### PR TITLE
fix: use ubuntu-latest instead of ubuntu-18.04

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
## 설명

<!-- 해당 PR에 대한 간단한 설명을 적어주세요. -->

https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/

`ubuntu-18.04` 이미지는 더이상 사용되지 않으며, 이로 인해 해당 Action이 계속 실패했습니다.

## 연관 이슈

<!-- 해당 PR과 연관된 이슈가 존재한다면 이슈 번호를 적어주세요. (예시: resolved #1) -->

fixes #567 

## 체크리스트

- [ ] [번역 가이드](../CONTRIBUTING.md)를 준수했습니다.
- [ ] [맞춤법 검사기](http://speller.cs.pusan.ac.kr/)를 통해 문서를 검사했습니다.
