### PR TITLE
fix: move philosophy to guide from config dir

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -179,6 +179,10 @@ export default defineConfig({
               link: '/guide/troubleshooting',
             },
             {
+              text: '프로젝트 철학',
+              link: '/guide/philosophy',
+            },
+            {
               text: 'v3에서 마이그레이션하기',
               link: '/guide/migration',
             },
@@ -233,10 +237,6 @@ export default defineConfig({
             {
               text: '빌드 옵션',
               link: '/config/build-options',
-            },
-            {
-              text: '프로젝트 철학',
-              link: '/guide/philosophy',
             },
             {
               text: '프리뷰 옵션',


### PR DESCRIPTION
## 설명

<!-- 해당 PR에 대한 간단한 설명을 적어주세요. -->

프로젝트 철학 문서가 잘못된 위치에 존재했습니다.

## 연관 이슈

<!-- 해당 PR과 연관된 이슈가 존재한다면 이슈 번호를 적어주세요. (예시: resolved #1) -->

~resolved #~

## 체크리스트

- [ ] [번역 가이드](https://github.com/vitejs/docs-ko/blob/main/CONTRIBUTING.md)를 준수했습니다.
- [ ] [맞춤법 검사기](http://speller.cs.pusan.ac.kr/)를 통해 문서를 검사했습니다.
