### PR TITLE
docs(sync): update actions/upload-pages-artifact version to v3

### DIFF
--- a/guide/static-deploy.md
+++ b/guide/static-deploy.md
@@ -108,7 +108,7 @@ $ npm run preview
          - name: Setup Pages
            uses: actions/configure-pages@v4
          - name: Upload artifact
-           uses: actions/upload-pages-artifact@v2
+           uses: actions/upload-pages-artifact@v3
            with:
              # dist 디렉터리 업로드
              path: './dist'


### PR DESCRIPTION
## 설명

<!-- 해당 PR에 대한 간단한 설명을 적어주세요. -->
github pages 정적 배포 시 `upload-pages-artifact@v2`가  [2024년 6월 30일에 지원 중단](https://github.com/actions/upload-artifact?tab=readme-ov-file#actionsupload-artifact)되어 배포가 되지 않는 이슈를 확인했습니다.

https://vite.dev/guide/static-deploy#github-pages 와 sync를 맞췄습니다.
```diff
- uses: actions/upload-pages-artifact@v2
+ uses: actions/upload-pages-artifact@v3
```
## 연관 이슈

<!-- 해당 PR과 연관된 이슈가 존재한다면 이슈 번호를 적어주세요. (예시: resolved #1) -->

resolved #

## 체크리스트

- [x] [번역 가이드](https://github.com/vitejs/docs-ko/blob/main/CONTRIBUTING.md)를 준수했습니다.
- [x] [맞춤법 검사기](http://speller.cs.pusan.ac.kr/)를 통해 문서를 검사했습니다.
