### PR TITLE
docs(Vite의 환경 변수와 모드): 잘못된 코드 예제 수정

### DIFF
--- a/guide/env-and-mode.md
+++ b/guide/env-and-mode.md
@@ -111,7 +111,7 @@ VITE_BAR=bar
 interface ViteTypeOptions {
   // 아래 라인을 추가하면, ImportMetaEnv 타입을 엄격하게 설정해
   // 알 수 없는 키를 허용하지 않게 할 수 있습니다.
-  // strictImportEnv: unknown
+  // strictImportMetaEnv: unknown
 }
 
 interface ImportMetaEnv {


### PR DESCRIPTION
## 설명

문서에서 발견된 잘못된 코드 예제를 수정했습니다.

[영문 링크](https://vite.dev/guide/env-and-mode#intellisense-for-typescript)
[한글 링크](https://ko.vite.dev/guide/env-and-mode.html#intellisense-for-typescript)

## 체크리스트

- [x] [번역 가이드](https://github.com/vitejs/docs-ko/blob/main/CONTRIBUTING.md)를 준수했습니다.
- [x] [맞춤법 검사기](http://speller.cs.pusan.ac.kr/)를 통해 문서를 검사했습니다.
