### PR TITLE
docs(config): translate batch from PR #1366 (partial)

### DIFF
--- a/config/build-options.md
+++ b/config/build-options.md
@@ -6,15 +6,15 @@
 
 - **타입:** `string | string[]`
 - **기본값:** `'baseline-widely-available'`
-- **관련 항목:** [브라우저 지원 현황](/guide/build#browser-compatibility)
+- **관련 항목:** [브라우저 호환성](/guide/build#browser-compatibility)
 
-최종 번들에 대한 브라우저 호환성 타깃입니다. 기본값은 Vite 전용 값인 `'baseline-widely-available'`로, 2025-05-01에 [Baseline](https://web-platform-dx.github.io/web-features/) Widely Available에 포함된 브라우저를 타깃으로 합니다. 구체적으로는 `['chrome107', 'edge107', 'firefox104', 'safari16']`입니다.
+최종 번들에 대한 브라우저 호환성 타깃입니다. 기본값은 Vite 전용 값인 `'baseline-widely-available'`로, 2026-01-01에 [Baseline](https://web-platform-dx.github.io/web-features/) Widely Available에 포함된 브라우저를 타깃으로 합니다. 구체적으로는 `['chrome111', 'edge111', 'firefox114', 'safari16.4']`입니다.
 
-또 다른 Vite 한정 옵션은 `'esnext'` 로, 네이티브 동적 Import를 지원하며 트랜스파일링을 최소한만 수행합니다.
+또 다른 Vite 한정 옵션은 `'esnext'`로, 네이티브 동적 Import를 지원한다고 가정하며 트랜스파일링을 최소한만 수행합니다.
 
-변환은 esbuild로 수행되며, 값은 유효한 [esbuild 타깃 옵션](https://esbuild.github.io/api/#target)이어야 합니다. 커스텀 타깃은 ES 버전 (예: `es2015`)이나 버전이 있는 브라우저 (예: `chrome58`) 또는 다중 타깃 문자열의 배열이 될 수 있습니다.
+변환은 Oxc Transformer로 수행되며, 값은 유효한 [Oxc Transformer 타깃 옵션](https://oxc.rs/docs/guide/usage/transformer/lowering#target)이어야 합니다. 커스텀 타깃은 ES 버전 (예: `es2015`)이나 버전이 있는 브라우저 (예: `chrome58`) 또는 다중 타깃 문자열의 배열이 될 수 있습니다.
 
-코드안에 esbuild로 안전하게 트랜스파일 할 수 없는 기능이 포함된 경우 빌드는 실패할 것입니다. 자세한 점은 [esbuild 문서](https://esbuild.github.io/content-types/#javascript)를 확인하세요.
+코드에 Oxc로 안전하게 트랜스파일 할 수 없는 기능이 포함된 경우 빌드는 경고를 출력합니다. 자세한 내용은 [Oxc 문서](https://oxc.rs/docs/guide/usage/transformer/lowering#warnings)를 확인하세요.
 
 ## build.modulePreload {#build-modulepreload}
 
@@ -70,7 +70,7 @@ modulePreload: {
 
 - **타입:** `boolean`
 - **기본값:** `true`
-- **사용 중단** `build.modulePreload.polyfill`을 사용하세요.
+- **사용 중단** 대신 `build.modulePreload.polyfill`을 사용하세요
 
 [module preload polyfill](https://guybedford.com/es-module-preloading-integrity#modulepreload-polyfill)을 자동으로 주입할지 여부입니다.
 
@@ -91,11 +91,11 @@ modulePreload: {
 ## build.assetsInlineLimit {#build-assetsinlinelimit}
 
 - **타입:** `number` | `((filePath: string, content: Buffer) => boolean | undefined)`
-- **기본값:** `4096` (4KiB)
+- **기본값:** `4096` (4 KiB)
 
 이 값보다 작은 크기로 import 되거나 참조된 에셋은 부가적인 http 요청을 피하고자 base64 URL로 인라인 처리됩니다. 만일 인라인 변환을 사용하지 않으려면 `0`으로 설정하세요.
 
-콜백이 전달되면, boolean을 반환하여 opt-in 또는 opt-out 할 수 있습니다(여기서 opt-in은 인라인을, opt-out은 기본값을 사용합니다. 자세한 구현 사항은 [커밋](https://github.com/vitejs/vite/commit/4d1342ebe0969cbcfc9c6d7fc5347f85df07df7f#diff-91776e7c6039d23a070162f02a69cd46046a2095bd5ecb384ae9e27f2ea5288fR414-R416)을 참고해 주세요. - 옮긴이). 반환되는 값이 없으면 기본 로직이 적용됩니다.
+콜백이 전달되면, boolean을 반환하여 opt-in 또는 opt-out 할 수 있습니다. 반환되는 값이 없으면 기본 로직이 적용됩니다.
 
 Git LFS(Large File Storage) 자리 표시자는 해당 파일의 내용을 포함하고 있지 않기에 인라인에서는 자동으로 제외됩니다.
 
@@ -121,7 +121,7 @@ CSS 코드 분할을 활성화/비활성화합니다. 활성화된 경우 비동
 - **타입:** `string | string[]`
 - **기본값:** [`build.target`](#build-target)과 동일
 
-이 옵션을 사용하면 CSS 축소 시 타깃이 되는 브라우저를 설정할 수 있습니다.
+이 옵션을 사용하면 JavaScript 트랜스파일링에 사용되는 타깃과 다른 CSS 축소화용 브라우저 타깃을 설정할 수 있습니다.
 
 일반적으로 비주류 브라우저를 대상으로 하는 경우에만 사용되며, Android WeChat WebView를 예로 들 수 있습니다.
 이 브라우저는 대부분의 최신 JavaScript 문법을 지원하지만 [16진수 CSS 색상 표기법인 `#RGBA`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#rgb_colors)를 지원하지 않습니다.
@@ -129,10 +129,16 @@ CSS 코드 분할을 활성화/비활성화합니다. 활성화된 경우 비동
 
 ## build.cssMinify {#build-cssminify}
 
-- **타입:** `boolean | 'esbuild' | 'lightningcss'`
-- **기본값:** 클라이언트는 [`build.minify`](#build-minify)와 동일, SSR은 `'esbuild'`
+- **타입:** `boolean | 'lightningcss' | 'esbuild'`
+- **기본값:** `'lightningcss'`, 단 클라이언트 빌드에서 [`build.minify`](#build-minify)가 비활성화된 경우 `false`
 
-이 옵션을 사용하면 기본값이 `build.minify`로 설정되는 대신 CSS 축소화를 구체적으로 재정의할 수 있으므로, JS와 CSS를 별도로 축소화할 수 있습니다. Vite는 기본적으로 `esbuild`를 사용해 CSS를 축소화하지만, 옵션을 `'lightningcss'`로 설정하면 [Lightning CSS](https://lightningcss.dev/minification.html)를 사용할 수도 있습니다. 이를 선택한 경우, [`css.lightningcss`](./shared-options.md#css-lightningcss)를 통해 설정이 가능합니다.
+이 옵션을 사용하면 기본값이 `build.minify`로 설정되는 대신 CSS 축소화를 구체적으로 재정의할 수 있으므로, JS와 CSS를 별도로 축소화할 수 있습니다. Vite는 기본적으로 [Lightning CSS](https://lightningcss.dev/minification.html)를 사용해 CSS를 축소화합니다. [`css.lightningcss`](./shared-options.md#css-lightningcss)를 통해 설정할 수 있습니다. esbuild를 대신 사용하려면 옵션을 `'esbuild'`로 설정하세요.
+
+`'esbuild'`로 설정한 경우 esbuild를 설치해야 합니다.
+
+```sh
+npm add -D esbuild
+```
 
 ## build.sourcemap {#build-sourcemap}
 
@@ -141,24 +147,25 @@ CSS 코드 분할을 활성화/비활성화합니다. 활성화된 경우 비동
 
 프로덕션에서 소스 맵을 생성합니다. `true`인 경우 별도의 소스 맵 파일이 생성됩니다. `'inline'`인 경우 소스 맵이 결과 출력 파일에 데이터 URI로 추가됩니다. `'hidden'`은 번들 파일의 해당 소스 맵 설명이 표시되지 않는 경우를 제외하고 `true`와 같이 작동합니다.
 
+## build.rolldownOptions {#build-rolldownoptions}
+
+- **타입:** [`RolldownOptions`](https://rolldown.rs/reference/)
+
+기반 Rolldown 번들을 직접 커스텀합니다. 이는 Rolldown 설정 파일에서 내보낼 수 있는 옵션과 같으며 Vite의 내부 Rolldown 옵션과 병합됩니다. 더 자세한 내용은 [Rolldown 옵션 문서](https://rolldown.rs/reference/)를 참고하세요.
+
 ## build.rollupOptions {#build-rollupoptions}
 
-- **타입:** [`RollupOptions`](https://rollupjs.org/configuration-options/)
+- **타입:** `RolldownOptions`
+- **사용 중단**
 
-기존 Rollup 번들을 커스텀합니다. 이는 Rollup 설정 파일에서 내보낼 수 있는 옵션과 같으며 Vite의 내부 Rollup 옵션과 병합됩니다. 더 자세한 점은 [Rollup 옵션 문서](https://rollupjs.org/configuration-options/)를 참고하세요.
-
-## build.commonjsOptions {#build-commonjsoptions}
-
-- **타입:** [`RollupCommonJSOptions`](https://github.com/rollup/plugins/tree/master/packages/commonjs#options)
-
-[@rollup/plugin-commonjs](https://github.com/rollup/plugins/tree/master/packages/commonjs)에 전달할 옵션입니다.
+이 옵션은 `build.rolldownOptions` 옵션의 별칭입니다. 대신 `build.rolldownOptions` 옵션을 사용하세요.
 
 ## build.dynamicImportVarsOptions {#build-dynamicimportvarsoptions}
 
-- **타입:** [`RollupDynamicImportVarsOptions`](https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars#options)
+- **타입:** `{ include?: string | RegExp | (string | RegExp)[], exclude?: string | RegExp | (string | RegExp)[] }`
 - **관련 항목:** [동적 Import](/guide/features#dynamic-import)
 
-[@rollup/plugin-dynamic-import-vars](https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars)에 전달할 옵션입니다.
+변수가 포함된 동적 임포트를 변환할지 여부입니다.
 
 ## build.lib {#build-lib}
 
@@ -185,15 +192,66 @@ export default defineConfig({
 })
 ```
 
+## build.license {#build-license}
+
+- **타입:** `boolean | { fileName?: string }`
+- **기본값:** `false`
+- **관련 항목:** [라이선스](/guide/features#license)
+
+`true`로 설정하면 빌드가 번들에 포함된 모든 디펜던시의 라이선스를 포함하는 `.vite/license.md` 파일을 생성합니다.
+
+`fileName`이 전달되면 `outDir`을 기준으로 하는 라이선스 파일 이름으로 사용됩니다. `.json`으로 끝나는 경우에는 원시 JSON 메타데이터가 대신 생성되며 추가 처리에 사용할 수 있습니다. 예를 들어:
+
+```json
+[
+  {
+    "name": "dep-1",
+    "version": "1.2.3",
+    "identifier": "CC0-1.0",
+    "text": "CC0 1.0 Universal\n\n..."
+  },
+  {
+    "name": "dep-2",
+    "version": "4.5.6",
+    "identifier": "MIT",
+    "text": "MIT License\n\n..."
+  }
+]
+```
+
+::: tip
+
+빌드된 코드에서 라이선스 파일을 참조하려면 [`build.rolldownOptions.output.postBanner`](https://rolldown.rs/reference/OutputOptions.postBanner#postbanner)를 사용하여 파일 상단에 주석을 주입할 수 있습니다. 예를 들어:
+
+```js twoslash [vite.config.js]
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  build: {
+    license: true,
+    rolldownOptions: {
+      output: {
+        postBanner:
+          '/* See licenses of bundled dependencies at https://example.com/license.md */',
+      },
+    },
+  },
+})
+```
+
+:::
+
 ## build.manifest {#build-manifest}
 
 - **타입:** `boolean | string`
 - **기본값:** `false`
-- **관련 항목:** [백엔드 프레임워크와 함께 사용하기](/guide/backend-integration)
+- **관련 항목:** [백엔드 통합](/guide/backend-integration)
 
 해시되지 않은 에셋 파일 이름과 해시된 버전 간 매핑을 포함하는 매니패스트 파일을 생성할지 여부입니다. 이는 서버 프레임워크에서 올바른 에셋 링크를 렌더링하는 데 사용될 수 있습니다.
 
 값이 문자열이면 `build.outDir`을 기준으로 하는 매니페스트 파일 경로로 사용됩니다. `true`면 `.vite/manifest.json`이 경로가 됩니다.
+
+플러그인을 작성하고 있으며 빌드 중 각 출력 청크 또는 에셋의 관련 CSS와 정적 에셋을 검사해야 한다면 [`viteMetadata` 출력 번들 메타데이터 API](/guide/api-plugin#output-bundle-metadata)도 사용할 수 있습니다.
 
 ## build.ssrManifest {#build-ssrmanifest}
 
@@ -201,7 +259,7 @@ export default defineConfig({
 - **기본값:** `false`
 - **관련 항목:** [서버 측 렌더링](/guide/ssr)
 
-프로덕션 환경에서 필요한 스타일 링크 및 에셋 프리로드 디렉티브를 식별하는 데 사용되는 SSR 매니페스트 파일을 생성할지 여부입니다.
+프로덕션 환경에서 스타일 링크와 에셋 프리로드 디렉티브를 결정하기 위한 SSR 매니페스트 파일을 생성할지 여부입니다.
 
 값이 문자열이면 `build.outDir`을 기준으로 하는 매니페스트 파일 경로로 사용됩니다. `true`면 `.vite/ssr-manifest.json`이 경로가 됩니다.
 
@@ -211,7 +269,7 @@ export default defineConfig({
 - **기본값:** `false`
 - **관련 항목:** [서버 측 렌더링](/guide/ssr)
 
-서버 측 렌더링으로 빌드합니다. 설정 값은 SSR 항목을 직접 지정하는 문자열이거나, `rollupOptions.input`을 통해 SSR 항목을 지정해야 하는 `true`가 될 수 있습니다.
+SSR 지향 빌드를 생성합니다. 설정 값은 SSR 항목을 직접 지정하는 문자열이거나, `rollupOptions.input`을 통해 SSR 항목을 지정해야 하는 `true`가 될 수 있습니다.
 
 ## build.emitAssets {#build-emitassets}
 
@@ -229,16 +287,19 @@ SSR 빌드 중에는 정적 에셋이 따로 생성되지 않는데, 이는 클�
 
 ## build.minify {#build-minify}
 
-- **타입:** `boolean | 'terser' | 'esbuild'`
-- **기본값:** 클라이언트 빌드에는 `'esbuild'`를, SSR 빌드에는 `false`를 사용
+- **타입:** `boolean | 'oxc' | 'terser' | 'esbuild'`
+- **기본값:** 클라이언트 빌드에는 `'oxc'`, SSR 빌드에는 `false`
 
-코드 경량화를 사용하지 않으려면 `false`로 설정하거나, 사용할 코드 경량화 도구를 지정하세요. 기본값은 [Esbuild](https://github.com/evanw/esbuild)로, Terser보다 20에서 40배가량 빠르며 압축률 또한 1 ~ 2%밖에 떨어지지 않습니다.
+축소화를 비활성화하려면 `false`로 설정하거나, 사용할 축소화 도구를 지정하세요. 기본값은 [Oxc Minifier](https://oxc.rs/docs/guide/usage/minifier)로, terser보다 30 ~ 90배 빠르며 압축률은 0.5 ~ 2% 정도만 낮습니다. [벤치마크](https://github.com/privatenumber/minification-benchmarks)
 
-참고로 `build.minify` 옵션은 `'es'`를 사용하는 라이브러리 모드에서 공백을 축소화하지 않습니다. 이는 Pure 애노테이션(`@__PURE__`)을 제거하고, 또 트리 셰이킹을 제대로 동작하지 못하게 만들기 때문입니다.
+`build.minify: 'esbuild'`는 사용 중단되었으며 향후 제거될 예정입니다.
 
-`'terser'`로 설정할 경우, Terser를 설치해야 합니다.
+참고로 `build.minify` 옵션은 lib 모드에서 `'es'` 포맷을 사용할 때 공백을 축소화하지 않습니다. 이는 Pure 애노테이션을 제거하고 트리 셰이킹을 깨뜨리기 때문입니다.
+
+`'esbuild'` 또는 `'terser'`로 설정한 경우 각각 esbuild 또는 Terser를 설치해야 합니다.
 
 ```sh
+npm add -D esbuild
 npm add -D terser
 ```
 
@@ -246,7 +307,7 @@ npm add -D terser
 
 - **타입:** `TerserOptions`
 
-Terser로 전달할 추가적인 [경량화 옵션](https://terser.org/docs/api-reference#minify-options)입니다.
+Terser로 전달할 추가적인 [축소화 옵션](https://terser.org/docs/api-reference#minify-options)입니다.
 
 `maxWorkers: number` 옵션을 전달하여 생성할 최대 워커 수를 지정할 수도 있습니다. 기본값은 CPU 수에서 1을 뺀 값입니다.
 
@@ -287,10 +348,10 @@ gzip 압축 크기 리포트를 활성화/비활성화합니다. 큰 출력 파�
 
 ## build.watch {#build-watch}
 
-- **타입:** [`WatcherOptions`](https://rollupjs.org/configuration-options/#watch)`| null`
+- **타입:** [`WatcherOptions`](https://rolldown.rs/reference/InputOptions.watch)`| null`
 - **기본값:** `null`
 
-Rollup 감시자를 사용하려면 `{}`로 설정하세요. 이는 대부분 빌드 전용 플러그인 또는 통합 프로세스를 포함하는 경우에 사용됩니다.
+rollup watcher를 활성화하려면 `{}`로 설정하세요. 이는 대부분 빌드 전용 플러그인 또는 통합 프로세스를 포함하는 경우에 사용됩니다.
 
 ::: warning Windows Subsystem for Linux (WSL) 2 에서 Vite 사용하기
 

--- a/config/dep-optimization-options.md
+++ b/config/dep-optimization-options.md
@@ -4,22 +4,22 @@
 
 별도로 명시되지 않은 한, 이 섹션의 옵션들은 개발 환경에서만 사용되는 디펜던시 최적화 도구에만 적용됩니다.
 
-## optimizeDeps.entries <NonInheritBadge />
+## optimizeDeps.entries <NonInheritBadge /> {#optimizedeps-entries}
 
 - **타입:** `string | string[]`
 
 기본적으로 Vite는 모든 `.html` 파일을 크롤링해 사전 번들링이 필요한 디펜던시를 탐지합니다(`node_modules`, `build.outDir`, `__tests__` 및 `coverage` 디렉터리는 무시). 만약 `build.rollupOptions.input`이 지정된 경우 Vite가 대신 해당 진입점을 탐색합니다.
 
-이 방식들이 맞지 않는다면 이 옵션을 사용해 커스텀 진입점을 지정할 수 있습니다. 값은 [`tinyglobby` 패턴](https://github.com/SuperchupuDev/tinyglobby) 또는 패턴 배열이어야 하며, 이는 Vite 프로젝트 루트를 기준으로 합니다. 이는 기본 진입점 추론 방식을 덮어쓰게 됩니다. `optimizeDeps.entries`가 명시적으로 정의된 경우 기본적으로 `node_modules`와 `build.outDir` 폴더만 무시됩니다. 다른 폴더들을 무시해야 하는 경우에는 진입점 목록의 일부로 `!`로 시작하는 무시 패턴을 사용할 수 있습니다. `node_modules` 문자열을 명시적으로 포함하는 패턴의 경우 `node_modules`는 무시되지 않습니다.
+이 방식들이 맞지 않는다면 이 옵션을 사용해 커스텀 진입점을 지정할 수 있습니다. 값은 Vite 프로젝트 루트를 기준으로 하는 [`tinyglobby` 패턴](https://superchupu.dev/tinyglobby/comparison) 또는 패턴 배열이어야 합니다. 이는 기본 진입점 추론 방식을 덮어쓰게 됩니다. `optimizeDeps.entries`가 명시적으로 정의된 경우 기본적으로 `node_modules`와 `build.outDir` 폴더만 무시됩니다. 다른 폴더들을 무시해야 하는 경우에는 진입점 목록의 일부로 `!`로 시작하는 무시 패턴을 사용할 수 있습니다. `node_modules` 문자열을 명시적으로 포함하는 패턴의 경우 `node_modules`는 무시되지 않습니다.
 
-## optimizeDeps.exclude <NonInheritBadge />
+## optimizeDeps.exclude <NonInheritBadge /> {#optimizedeps-exclude}
 
 - **타입:** `string[]`
 
 사전 번들링에서 제외할 디펜던시 목록입니다.
 
 :::warning CommonJS
-CommonJS 디펜던시는 최적화에서 제외돼서는 안 됩니다. ESM 디펜던시가 최적화에서 제외되었지만 이와 중첩된(Nested) CommonJS 디펜던시가 있는 경우, CommonJS 디펜던시를 `optimizeDeps.include`에 추가해줘야 합니다:
+CommonJS 디펜던시는 최적화에서 제외돼서는 안 됩니다. ESM 디펜던시가 최적화에서 제외되었지만 중첩된 CommonJS 디펜던시가 있는 경우, CommonJS 디펜던시를 `optimizeDeps.include`에 추가해야 합니다. 예시:
 
 ```js twoslash
 import { defineConfig } from 'vite'
@@ -33,13 +33,13 @@ export default defineConfig({
 
 :::
 
-## optimizeDeps.include <NonInheritBadge />
+## optimizeDeps.include <NonInheritBadge /> {#optimizedeps-include}
 
 - **타입:** `string[]`
 
 기본적으로 `node_modules` 내부에 없는 연결된 패키지들은 미리 번들로 제공되지 않습니다. 이 옵션을 사용하여 연결된 패키지를 미리 번들로 묶을 수 있습니다.
 
-많은 수의 라이브러리를 디렉터리 깊은 곳에서까지 가져와야 하는 경우, 끝에 Glob 패턴을 지정해 모든 라이브러리를 한 번에 사전 번들로 묶을 수 있습니다. 이렇게 하면 유사한 라이브러리를 가져올 때마다 반복적으로 사전 번들링을 수행하는 것을 피할 수 있습니다. [이에 대한 피드백은 여기에 남겨주세요](https://github.com/vitejs/vite/discussions/15833). 예를 들어 다음과 같이 사용할 수 있습니다:
+**실험적 기능:** 많은 수의 라이브러리를 디렉터리 깊은 곳에서까지 가져와야 하는 경우, 끝에 Glob 패턴을 지정해 모든 라이브러리를 한 번에 사전 번들로 묶을 수 있습니다. 이렇게 하면 새로운 딥 임포트가 사용될 때마다 반복적으로 사전 번들링을 수행하는 것을 피할 수 있습니다. [피드백을 남겨주세요](https://github.com/vitejs/vite/discussions/15833). 예를 들어 다음과 같이 사용할 수 있습니다:
 
 ```js twoslash
 import { defineConfig } from 'vite'
@@ -51,52 +51,48 @@ export default defineConfig({
 })
 ```
 
-## optimizeDeps.esbuildOptions <NonInheritBadge />
+## optimizeDeps.rolldownOptions <NonInheritBadge /> {#optimizedeps-rolldownoptions}
 
-- **타입:** [`Omit`](https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys)`<`[`EsbuildBuildOptions`](https://esbuild.github.io/api/#general-options)`,
-| 'bundle'
-| 'entryPoints'
-| 'external'
-| 'write'
-| 'watch'
-| 'outdir'
-| 'outfile'
-| 'outbase'
-| 'outExtension'
-| 'metafile'>`
+- **타입:** <code>Omit<<a href="https://rolldown.rs/reference/Interface.RolldownOptions">RolldownOptions</a>, 'input' | 'logLevel' | 'output'> & { output?: Omit<<a href="https://rolldown.rs/reference/#:~:text=Output%20Options">RolldownOutputOptions</a>, 'format' | 'sourcemap' | 'dir' | 'banner'> }</code>
 
-디펜던시 스캐닝 및 최적화 중 Esbuild에 전달할 옵션입니다.
+디펜던시 스캐닝 및 최적화 중 Rolldown에 전달할 옵션입니다.
 
-특정 옵션은 Vite의 디펜던시 최적화와 호환되지 않기에 생략되었습니다.
+특정 옵션은 변경하면 Vite의 디펜던시 최적화와 호환되지 않기에 생략되었습니다.
 
-- `external`은 생략됩니다. 이 대신 Vite의 `optimizeDeps.exclude` 옵션을 사용합니다.
 - `plugins`는 Vite의 디펜던시 플러그인과 병합됩니다.
 
-## optimizeDeps.force <NonInheritBadge />
+## optimizeDeps.esbuildOptions <NonInheritBadge /> {#optimizedeps-esbuildoptions}
+
+- **타입:** <code>Omit<<a href="https://esbuild.github.io/api/#general-options">EsbuildBuildOptions</a>, 'bundle' | 'entryPoints' | 'external' | 'write' | 'watch' | 'outdir' | 'outfile' | 'outbase' | 'outExtension' | 'metafile'></code>
+- **지원 중단 예정**
+
+이 옵션은 내부적으로 `optimizeDeps.rolldownOptions`로 변환됩니다. 대신 `optimizeDeps.rolldownOptions`를 사용하세요.
+
+## optimizeDeps.force <NonInheritBadge /> {#optimizedeps-force}
 
 - **타입:** `boolean`
 
 `true`로 설정하면 최적화되어 캐시된 디펜던시들을 무시하고, 디펜던시 사전 번들링을 강제로 실행합니다.
 
-## optimizeDeps.noDiscovery <NonInheritBadge />
+## optimizeDeps.noDiscovery <NonInheritBadge /> {#optimizedeps-nodiscovery}
 
 - **타입:** `boolean`
 - **기본값:** `false`
 
 `true`로 설정하면 자동 디펜던시 탐색이 비활성화되고 `optimizeDeps.include`에 나열된 디펜던시만 최적화됩니다. CJS 전용 디펜던시는 개발 중에 반드시 `optimizeDeps.include`에 포함되어야 합니다.
 
-## optimizeDeps.holdUntilCrawlEnd <NonInheritBadge />
+## optimizeDeps.holdUntilCrawlEnd <NonInheritBadge /> {#optimizedeps-holduntilcrawlend}
 
-- **실험적 기능**: [이 곳에 피드백을 남겨주세요](https://github.com/vitejs/vite/discussions/15834)
+- **실험적 기능:** [피드백을 남겨주세요](https://github.com/vitejs/vite/discussions/15834)
 - **타입:** `boolean`
 - **기본값:** `true`
 
-이 옵션이 활성화되어 있으면 콜드 스타트 시 모든 정적 에셋이 크롤링될 때까지 디펜던시 최적화가 완료되지 않습니다. 이는 크롤링 도중 새로운 디펜던시가 발견되어 공통 청크를 다시 만들어야 하는 경우 전체 페이지를 다시 로드해야 하는 상황을 피할 수 있습니다(자세한 설명은 [이 코멘트](https://github.com/vitejs/vite/pull/8869#issuecomment-1172902125)를 참고해 주세요. - 옮긴이). 만약 디펜던시 스캐너로 `include`에 정의된 목록을 포함해 모든 디펜던시를 찾을 수 있다면, 브라우저가 병렬로 더 많은 요청을 처리할 수 있도록 이 옵션을 비활성화하는 것이 좋습니다.
+이 옵션이 활성화되어 있으면 콜드 스타트 시 모든 정적 임포트가 크롤링될 때까지 최초의 최적화된 디펜던시 결과를 보류합니다. 이는 새로운 디펜던시가 발견되어 새 공통 청크 생성을 트리거할 때 전체 페이지를 다시 로드해야 하는 상황을 피할 수 있습니다. 스캐너와 `include`에 명시적으로 정의된 항목으로 모든 디펜던시를 찾을 수 있다면, 브라우저가 병렬로 더 많은 요청을 처리할 수 있도록 이 옵션을 비활성화하는 것이 좋습니다.
 
-## optimizeDeps.disabled <NonInheritBadge />
+## optimizeDeps.disabled <NonInheritBadge /> {#optimizedeps-disabled}
 
 - **지원 중단 예정**
-- **실험적 기능:** [이 곳에 피드백을 남겨주세요](https://github.com/vitejs/vite/discussions/13839)
+- **실험적 기능:** [피드백을 남겨주세요](https://github.com/vitejs/vite/discussions/13839)
 - **타입:** `boolean | 'build' | 'dev'`
 - **기본값:** `'build'`
 
@@ -105,12 +101,12 @@ export default defineConfig({
 최적화를 완전히 비활성화하려면, `optimizeDeps.noDiscovery: true`를 사용해 디펜던시 자동 탐색을 허용하지 않고, `optimizeDeps.include`를 정의하지 않거나 비워두세요.
 
 :::warning
-빌드 중 디펜던시를 최적화하는 것은 **실험적** 기능이었습니다. 이 전략을 시도하는 프로젝트는 `build.commonjsOptions: { include: [] }`를 사용해 `@rollup/plugin-commonjs`를 제거해야 합니다. 이렇게 했다면 번들링 중 CJS 패키지를 지원하기 위해 다시 활성화하도록 안내하는 경고가 표시됩니다.
+빌드 중 디펜던시를 최적화하는 것은 **실험적** 기능이었습니다. 이 전략을 시도하는 프로젝트는 `build.commonjsOptions: { include: [] }`를 사용해 `@rollup/plugin-commonjs`를 제거해야 합니다. 이렇게 했다면 번들링 중 CJS 전용 패키지를 지원하기 위해 다시 활성화하도록 안내하는 경고가 표시됩니다.
 :::
 
-## optimizeDeps.needsInterop <NonInheritBadge />
+## optimizeDeps.needsInterop <NonInheritBadge /> {#optimizedeps-needsinterop}
 
 - **실험적 기능**
 - **타입:** `string[]`
 
-명시된 디펜던시를 가져올 때 ESM 상호 운용을 강제합니다. Vite는 디펜던시가 상호 운용 필요한지를 정확하게 감지할 수 있기 때문에 이 옵션은 일반적으로 필요하지 않습니다. 그러나 디펜던시들의 다양한 조합에 따라 이들 중 일부는 사전 번들링이 다르게 적용될 수 있습니다. 이 패키지들을 `needsInterop`에 추가하면 전체 페이지에 대한 리로드를 피하고 콜드 스타트를 가속할 수 있습니다. 만약 사용하는 디펜던시가 이 상황에 해당한다면, 설정 파일에 이 패키지 이름을 추가하라는 경고가 표시됩니다.
+명시된 디펜던시를 가져올 때 ESM 상호 운용을 강제합니다. Vite는 디펜던시가 상호 운용이 필요한지를 정확하게 감지할 수 있기 때문에 이 옵션은 일반적으로 필요하지 않습니다. 그러나 디펜던시들의 다양한 조합에 따라 이들 중 일부는 다르게 사전 번들링될 수 있습니다. 이 패키지들을 `needsInterop`에 추가하면 전체 페이지 리로드를 피하여 콜드 스타트를 가속할 수 있습니다. 사용하는 디펜던시 중 하나가 이 상황에 해당한다면, 설정의 이 배열에 패키지 이름을 추가하라는 경고가 표시됩니다.

--- a/config/preview-options.md
+++ b/config/preview-options.md
@@ -21,7 +21,7 @@ Vite 대신 다른 서버가 응답하는 경우가 있습니다.
 
 ## preview.allowedHosts {#preview-allowedhosts}
 
-- **타입:** `string | true`
+- **타입:** `string[] | true`
 - **기본값:** [`server.allowedHosts`](./server-options#server-allowedhosts)
 
 Vite가 응답할 수 있는 호스트 이름 목록입니다.
@@ -40,11 +40,11 @@ Vite가 응답할 수 있는 호스트 이름 목록입니다.
 ```js
 export default defineConfig({
   server: {
-    port: 3030
+    port: 3030,
   },
   preview: {
-    port: 8080
-  }
+    port: 8080,
+  },
 })
 ```
 

--- a/config/server-options.md
+++ b/config/server-options.md
@@ -10,35 +10,22 @@
 서버가 수신할 IP 주소를 지정합니다.
 LAN와 공용 주소를 포함한 모든 주소를 수신하려면 이 값을 `0.0.0.0` 또는 `true`로 설정하세요.
 
-CLI에서는 `--host 0.0.0.0` or `--host`로 설정될 수 있습니다.
+CLI에서는 `--host 0.0.0.0` 또는 `--host`를 사용해 설정할 수 있습니다.
 
 ::: tip 참고
 
 Vite 대신 다른 서버가 응답하는 경우가 있습니다.
 
-첫 번째 경우는 `localhost`를 사용하는 경우입니다. Node.js 버전이 v17 미만이라면 기본적으로 DNS로 확인된 주소의 결과를 재정렬합니다. `localhost`에 접근할 때 브라우저는 DNS를 사용해 주소를 확인하며, 해당 주소는 Vite가 수신하고 있는 주소와 다를 수 있습니다.
+첫 번째 경우는 `localhost`를 사용하는 경우입니다. Node.js의 [`dns.setDefaultResultOrder`](https://nodejs.org/docs/latest-v24.x/api/dns.html#dnssetdefaultresultorderorder)는 DNS로 확인된 주소의 순서를 변경하며, 브라우저는 Vite가 수신하고 있는 주소와 다른 확인된 주소를 사용할 수 있습니다. 주소가 다른 경우 Vite는 확인된 주소를 출력합니다.
 
-이 재정렬 동작을 비활성화하려면 [`dns.setDefaultResultOrder('verbatim')`](https://nodejs.org/api/dns.html#dns_dns_setdefaultresultorder_order)으로 설정해주세요. 이 때 Vite는 주소를 `localhost`로 표기합니다.
-
-```js twoslash [vite.config.js]
-import { defineConfig } from 'vite'
-import dns from 'node:dns'
-
-dns.setDefaultResultOrder('verbatim')
-
-export default defineConfig({
-  // 생략
-})
-```
-
-두 번째 경우는 와일드카드 호스트(예: `0.0.0.0`)가 사용되는 경우입니다. 와일드카드 호스트는 명시적으로 지정된 호스트보다 우선 순위가 낮기 때문에 이러한 상황이 발생될 수 있습니다.
+두 번째 경우는 와일드카드 호스트(예: `0.0.0.0`)가 사용되는 경우입니다. 와일드카드가 아닌 호스트에서 수신하는 서버가 와일드카드 호스트에서 수신하는 서버보다 우선하기 때문입니다.
 
 :::
 
 ::: tip LAN에서 WSL2의 서버에 액세스하기
 
 WSL2에서 Vite를 실행할 때, `host: true`를 설정하는 것만으로는 LAN에서 서버에 접근할 수 없습니다.
-[WSL 문서](https://learn.microsoft.com/en-us/windows/wsl/networking#accessing-a-wsl-2-distribution-from-your-local-area-network-lan)를 참고하세요.
+자세한 내용은 [WSL 문서](https://learn.microsoft.com/en-us/windows/wsl/networking#accessing-a-wsl-2-distribution-from-your-local-area-network-lan)를 참고하세요.
 
 :::
 
@@ -65,7 +52,7 @@ HTTPS를 사용하는 경우 이 검사는 건너뜁니다.
 
 ::: danger
 
-`server.allowedHosts`를 `true`로 설정하면 DNS 리바인딩 공격을 통해 어떤 웹사이트에서든 개발 서버에 요청을 보낼 수 있게 되며, 소스 코드와 콘텐츠가 유출될 수 있습니다. 따라서 항상 명시적으로 호스트 목록을 지정할 것을 강력히 권장합니다. 자세한 내용은 [GHSA-vg6x-rcgg-rjx6](https://github.com/vitejs/vite/security/advisories/GHSA-vg6x-rcgg-rjx6)를 참고해 주세요.
+`server.allowedHosts`를 `true`로 설정하면 DNS 리바인딩 공격을 통해 어떤 웹사이트에서든 개발 서버에 요청을 보낼 수 있게 되며, 소스 코드와 콘텐츠가 유출될 수 있습니다. 따라서 항상 명시적으로 호스트 목록을 지정할 것을 권장합니다. 자세한 내용은 [GHSA-vg6x-rcgg-rjx6](https://github.com/vitejs/vite/security/advisories/GHSA-vg6x-rcgg-rjx6)를 참고해 주세요.
 
 :::
 
@@ -92,9 +79,7 @@ HTTPS를 사용하는 경우 이 검사는 건너뜁니다.
 
 TLS + HTTP/2를 사용합니다. 값은 `https.createServer()`로 전달되는 [옵션 객체](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener)입니다.
 
-이 설정은 [`server.proxy` 옵션](#server-proxy)이 사용된다면 TLS만 사용하도록 다운그레이드된다는 점에 유의하세요.
-
-인증서는 유효한 것이 필요합니다. 기본적으로 프로젝트에 [@vitejs/plugin-basic-ssl](https://github.com/vitejs/vite-plugin-basic-ssl) 플러그인을 추가하면 자체 서명된 인증서가 자동으로 생성되고 캐시됩니다. 다만 직접 생성한 인증서를 사용하는 것이 좋습니다.
+인증서는 유효한 것이 필요합니다. 기본 설정의 경우 프로젝트 플러그인에 [@vitejs/plugin-basic-ssl](https://github.com/vitejs/vite-plugin-basic-ssl)을 추가할 수 있으며, 그러면 자체 서명된 인증서가 자동으로 생성되고 캐시됩니다. 다만 직접 인증서를 생성하는 것이 좋습니다.
 
 ## server.open {#server-open}
 
@@ -102,15 +87,15 @@ TLS + HTTP/2를 사용합니다. 값은 `https.createServer()`로 전달되는 [
 
 서버가 시작될 때 자동으로 브라우저에서 앱을 보여줍니다. 값이 문자열이면 URL의 경로명으로 사용됩니다. 원하는 특정 브라우저에서 열기를 원한다면, `process.env.BROWSER` (예: `firefox`) 환경 변수를 설정할 수 있습니다. `process.env.BROWSER_ARGS` 환경 변수를 통해 추가적인 인자를 전달할 수도 있습니다. (예: `--incognito`)
 
-추가로 이 `BROWSER`와 `BROWSER_ARGS`는 `.env` 파일에서 설정이 가능합니다. 자세한 내용은 [`open` 패키지 문서](https://github.com/sindresorhus/open#app)를 참고해주세요.
+`BROWSER`와 `BROWSER_ARGS`는 이를 구성하기 위해 `.env` 파일에서 설정할 수 있는 특별한 환경 변수이기도 합니다. 자세한 내용은 [`open` 패키지](https://github.com/sindresorhus/open#app)를 참고해주세요.
 
 **예제:**
 
 ```js
 export default defineConfig({
   server: {
-    open: '/docs/index.html'
-  }
+    open: '/docs/index.html',
+  },
 })
 ```
 
@@ -118,13 +103,13 @@ export default defineConfig({
 
 - **타입:** `Record<string, string | ProxyOptions>`
 
-개발 서버에 대한 커스텀 프록시 규칙을 구성합니다. `{ key: options }` 쌍의 객체를 전달할 수 있습니다. 경로가 해당 키로 시작하는 모든 요청은 지정된 대상으로 프록시됩니다. 키가 `^`로 시작하면 `RegExp`로 해석됩니다. `configure` 옵션은 프록시 인스턴스에 액세스하는 데 사용할 수 있습니다. 또한 프록시 규칙 중 하나라도 요청과 일치한다면, 해당 요청은 Vite에 의해 변환되지 않습니다.
+개발 서버에 대한 커스텀 프록시 규칙을 구성합니다. `{ key: options }` 쌍의 객체를 받습니다. 요청 경로가 해당 키로 시작하는 모든 요청은 지정된 대상으로 프록시됩니다. 키가 `^`로 시작하면 `RegExp`로 해석됩니다. `configure` 옵션은 프록시 인스턴스에 액세스하는 데 사용할 수 있습니다. 요청이 구성된 프록시 규칙 중 하나와 일치하면, 해당 요청은 Vite에 의해 변환되지 않습니다.
 
-참고로 [`base`](/config/shared-options.md#base)가 비상대적(Non-relative)인 경우, 각 키에 `base`를 접두사로 붙여야 합니다.
+참고로 비상대적 [`base`](/config/shared-options.md#base)를 사용하는 경우, 각 키에 해당 `base`를 접두사로 붙여야 합니다.
 
-또한 [`http-proxy-3`](https://github.com/sagemathinc/http-proxy-3#options)를 확장합니다. 추가 옵션은 [여기](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/middlewares/proxy.ts#L13)에서 확인할 수 있습니다.
+[`http-proxy-3`](https://github.com/sagemathinc/http-proxy-3#options)를 확장합니다. 추가 옵션은 [여기](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/middlewares/proxy.ts#L13)에서 확인할 수 있습니다.
 
-특정 상황(예: 서버 내부에서 사용되는 [connect](https://github.com/senchalabs/connect) 앱에 커스텀 미들웨어 추가)에서는 개발 서버를 직접 구성해야 할 수도 있습니다. 이를 위해서는 [플러그인](/guide/using-plugins.html)을 작성하고, [configureServer](/guide/api-plugin.html#configureserver) 훅을 이용해야 합니다. 자세한 것은 각 문서를 참고해주세요.
+특정 상황(예: 내부 [connect](https://github.com/senchalabs/connect) 앱에 커스텀 미들웨어 추가)에서는 기반 개발 서버도 구성하고 싶을 수 있습니다. 이를 위해서는 직접 [플러그인](/guide/using-plugins.html)을 작성하고 [configureServer](/guide/api-plugin.html#configureserver) 함수를 사용해야 합니다.
 
 **예제:**
 
@@ -132,7 +117,7 @@ export default defineConfig({
 export default defineConfig({
   server: {
     proxy: {
-      // 문자열만:
+      // 문자열 축약형:
       // http://localhost:5173/foo
       //   -> http://localhost:4567/foo
       '/foo': 'http://localhost:4567',
@@ -142,43 +127,43 @@ export default defineConfig({
       '/api': {
         target: 'http://jsonplaceholder.typicode.com',
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, '')
+        rewrite: (path) => path.replace(/^\/api/, ''),
       },
-      // 정규식(RegExp)과 함께:
+      // RegExp와 함께:
       // http://localhost:5173/fallback/
       //   -> http://jsonplaceholder.typicode.com/
       '^/fallback/.*': {
         target: 'http://jsonplaceholder.typicode.com',
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/fallback/, '')
+        rewrite: (path) => path.replace(/^\/fallback/, ''),
       },
       // 프록시 인스턴스 사용
       '/api': {
         target: 'http://jsonplaceholder.typicode.com',
         changeOrigin: true,
         configure: (proxy, options) => {
-          // proxy 변수에는 'http-proxy'의 인스턴스가 전달됩니다
-        }
+          // proxy는 'http-proxy'의 인스턴스가 됩니다
+        },
       },
       // 웹소켓 또는 socket.io 프록시:
       // ws://localhost:5173/socket.io
       //   -> ws://localhost:5174/socket.io
-      // `rewriteWsOrigin`을 사용할 때는 주의하세요.
-      // CSRF 공격에 노출될 수 있습니다.
+      // `rewriteWsOrigin`을 사용할 때는 프록시가 CSRF 공격에
+      // 노출될 수 있으므로 주의하세요.
       '/socket.io': {
         target: 'ws://localhost:5174',
         ws: true,
         rewriteWsOrigin: true,
-      }
-    }
-  }
+      },
+    },
+  },
 })
 ```
 
 ## server.cors {#server-cors}
 
 - **타입:** `boolean | CorsOptions`
-- **기본값:** `{ origin: /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/ }` (`127.0.0.1` 및 `::1` 같은 localhost 허용)
+- **기본값:** `{ origin: /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/ }` (localhost, `127.0.0.1` 및 `::1` 허용)
 
 개발 서버 CORS를 설정합니다.  [옵션 객체](https://github.com/expressjs/cors#configuration-options)를 전달해 상세한 동작을 설정하거나, 모든 출처를 허용하기 위해 `true`로 설정할 수 있습니다.
 
@@ -196,35 +181,73 @@ export default defineConfig({
 
 ## server.hmr {#server-hmr}
 
-- **타입:** `boolean | { protocol?: string, host?: string, port?: number | false, path?: string, timeout?: number, overlay?: boolean, clientPort?: number, server?: Server }`
+- **타입:** `boolean | { protocol?: string, host?: string, port?: number, path?: string, timeout?: number, overlay?: boolean, clientPort?: number, server?: Server }`
 
-HMR 연결을 설정하거나 사용하지 않을 수 있습니다. (HMR 웹 소켓이 http 서버와 다른 주소를 사용해야 하는 경우)
+HMR 연결을 설정하거나 사용하지 않을 수 있습니다. (HMR 웹소켓이 http 서버와 다른 주소를 사용해야 하는 경우)
 
 서버 오류 오버레이를 사용하지 않으려면 `server.hmr.overlay`를 `false`로 설정하세요.
 
 `protocol`은 HMR 연결에 사용되는 웹소켓 프로토콜을 설정합니다: `ws` (웹소켓) 또는 `wss` (보안 웹소켓) 값을 갖습니다.
 
-`clientPort`는 클라이언트 측의 포트만 재정의하는 고급 옵션으로, 클라이언트 코드에서 찾는 것과 다른 포트에서 웹 소켓을 제공할 수 있습니다.
+`clientPort`는 클라이언트 측의 포트만 재정의하는 고급 옵션으로, 클라이언트 코드에서 찾는 것과 다른 포트에서 웹소켓을 제공할 수 있습니다.
 
-`server.hmr.server` 옵션이 정의되면 Vite는 제공된 서버를 통해 HMR 연결 요청을 처리합니다. 미들웨어 모드가 아니라면, Vite는 기존 서버를 통해 HMR 연결 요청을 처리합니다. 이는 자체적으로 서명된 인증서를 사용하거나 단일 포트의 네트워크를 통해 Vite를 제공하려는 경우 유용합니다.
+`server.hmr.server`가 정의되면 Vite는 제공된 서버를 통해 HMR 연결 요청을 처리합니다. 미들웨어 모드가 아니라면, Vite는 기존 서버를 통해 HMR 연결 요청 처리를 시도합니다. 이는 자체 서명된 인증서를 사용하거나 단일 포트의 네트워크를 통해 Vite를 노출하려는 경우 유용합니다.
 
-예제는 [`vite-setup-catalogue`](https://github.com/sapphi-red/vite-setup-catalogue)를 참고해주세요.
+몇 가지 예제는 [`vite-setup-catalogue`](https://github.com/sapphi-red/vite-setup-catalogue)를 참고해주세요.
 
 ::: tip 참고
 
-기본적으로 Vite는 리버스 프록시가 WebSocket 프록시를 지원한다고 가정하고 동작합니다. 만약 Vite HMR 클라이언트가 WebSocket 연결에 실패하게 되면, 클라이언트는 리버스 프록시 대신 WebSocket을 Vite HMR 서버에 직접 연결합니다:
+기본 구성에서는 Vite 앞단의 리버스 프록시가 WebSocket 프록시를 지원해야 합니다. Vite HMR 클라이언트가 WebSocket 연결에 실패하면, 클라이언트는 리버스 프록시를 우회하여 WebSocket을 Vite HMR 서버에 직접 연결하는 방식으로 폴백합니다:
 
 ```
 Direct websocket connection fallback. Check out https://vite.dev/config/server-options.html#server-hmr to remove the previous connection error.
 ```
 
-위와 같은 상황이 발생될 때 브라우저에 나타나는 이 오류는 무시해도 됩니다. 다만 아래의 작업들 중 하나를 통해 직접 리버스 프록시를 우회해서 오류를 나타나지 않게끔 할 수도 있습니다:
+폴백이 발생할 때 브라우저에 나타나는 오류는 무시해도 됩니다. 리버스 프록시를 직접 우회하여 오류를 피하려면 다음 중 하나를 수행할 수 있습니다:
 
 - WebSocket도 프록시하도록 리버스 프록시를 구성
-- [`server.strictPort` 옵션의 값을 `true`로](#server-strictport), 그리고 `server.hmr.clientPort`를 `server.port`와 동일한 값으로 설정
+- [`server.strictPort = true`](#server-strictport)를 설정하고 `server.hmr.clientPort`를 `server.port`와 동일한 값으로 설정
 - `server.hmr.port`를 [`server.port`](#server-port)와 다른 값으로 설정
 
 :::
+
+## server.forwardConsole {#server-forwardconsole}
+
+- **타입:** `boolean | { unhandledErrors?: boolean, logLevels?: ('error' | 'warn' | 'info' | 'log' | 'debug')[] }`
+- **기본값:** 자동 ([`@vercel/detect-agent`](https://www.npmjs.com/package/@vercel/detect-agent)를 기반으로 AI 코딩 에이전트가 감지되면 `true`, 그렇지 않으면 `false`)
+
+개발 중 브라우저 런타임 이벤트를 Vite 서버 콘솔로 전달합니다.
+
+- `true`는 처리되지 않은 오류와 `console.error` / `console.warn` 로그 전달을 활성화합니다.
+- `unhandledErrors`는 잡히지 않은 예외와 처리되지 않은 promise 거부 전달을 제어합니다.
+- `logLevels`는 어떤 `console.*` 호출을 전달할지 제어합니다.
+
+예를 들어:
+
+```js
+export default defineConfig({
+  server: {
+    forwardConsole: {
+      unhandledErrors: true,
+      logLevels: ['warn', 'error'],
+    },
+  },
+})
+```
+
+처리되지 않은 오류가 전달되면 서버 터미널에 향상된 형식으로 기록됩니다. 예를 들어:
+
+```log
+1:18:38 AM [vite] (client) [Unhandled error] Error: this is test error
+ > testError src/main.ts:20:8
+     18|
+     19| function testError() {
+     20|   throw new Error('this is test error')
+       |        ^
+     21| }
+     22|
+ > HTMLButtonElement.<anonymous> src/main.ts:6:2
+```
 
 ## server.warmup {#server-warmup}
 
@@ -233,7 +256,7 @@ Direct websocket connection fallback. Check out https://vite.dev/config/server-o
 
 미리 변환하고 그 결과물을 캐시할 파일 목록입니다. 서버 시작 시 초기 페이지 로드를 개선하고 변환 워터폴(변환이 순차적으로 이루어지는 현상 - 옮긴이)을 방지합니다.
 
-옵션의 `clientFiles`는 클라이언트에서만, `ssrFiles`는 SSR에서만 사용되는 파일 목록입니다. `root`를 기준으로 하는 파일 경로 또는 [`tinyglobby`](https://github.com/SuperchupuDev/tinyglobby) 패턴의 배열을 받습니다.
+옵션의 `clientFiles`는 클라이언트에서만, `ssrFiles`는 SSR에서만 사용되는 파일 목록입니다. `root`를 기준으로 하는 파일 경로 또는 [`tinyglobby` 패턴](https://superchupu.dev/tinyglobby/comparison)의 배열을 받습니다.
 
 Vite 개발 서버 시작 시 과부하가 걸리지 않도록 자주 사용되는 파일만 추가해주세요.
 
@@ -256,11 +279,11 @@ export default defineConfig({
 
 Vite 서버 감시자는 기본적으로 `root`를 감시하며, `.git/`, `node_modules/`, `test-results/`, 그리고 Vite의 `cacheDir` 및 `build.outDir` 디렉터리는 건너뜁니다. 감시하는 파일이 업데이트되면, Vite는 필요한 경우에만 HMR을 적용하고 페이지를 업데이트합니다.
 
-`null`로 설정하면 파일을 감시하지 않습니다. `server.watcher`는 (Node.js `EventEmitter`과)호환되는 이벤트 객체(Emitter)를 제공하지만, `add` 또는 `unwatch`를 호출해도 아무런 효과가 없습니다.
+`null`로 설정하면 파일을 감시하지 않습니다. [`server.watcher`](/guide/api-javascript.html#vitedevserver)는 호환되는 이벤트 이미터를 제공하지만, `add` 또는 `unwatch`를 호출해도 아무런 효과가 없습니다.
 
-::: warning `node_modules` 디렉터리에서 파일 감시하기
+::: warning `node_modules`에서 파일 감시하기
 
-현재 `node_modules` 디렉터리의 파일과 패키지는 감시할 수 없습니다. 더 많은 진행 상황과 해결 방법은 [#8619 이슈](https://github.com/vitejs/vite/issues/8619)를 참고해 주세요.
+현재 `node_modules`의 파일과 패키지는 감시할 수 없습니다. 더 많은 진행 상황과 해결 방법은 [#8619 이슈](https://github.com/vitejs/vite/issues/8619)를 참고해 주세요.
 
 :::
 
@@ -284,7 +307,7 @@ WSL2에서 Vite를 실행할 때, WSL2가 아닌 타 Windows 응용 프로그램
 
 미들웨어 모드로 Vite 서버를 생성합니다.
 
-- **관련 항목:** [appType](./shared-options.md#apptype), [SSR - 개발 서버 구성하기](/guide/ssr#setting-up-the-dev-server)
+- **관련 항목:** [appType](./shared-options#apptype), [SSR - 개발 서버 구성하기](/guide/ssr#setting-up-the-dev-server)
 
 - **예제:**
 
@@ -297,18 +320,18 @@ async function createServer() {
 
   // 미들웨어 모드에서 Vite 서버를 생성합니다
   const vite = await createViteServer({
-    server: { middlewareMode: 'ssr' },
+    server: { middlewareMode: true },
     // Vite의 기본 HTML 처리 미들웨어를 포함하지 않음
-    appType: 'custom'
+    appType: 'custom',
   })
-  // Vite의 연결(Connect) 인스턴스를 미들웨어로 사용
+  // vite의 connect 인스턴스를 미들웨어로 사용
   app.use(vite.middlewares)
 
   app.use('*', async (req, res) => {
-    // `appType`은 `'custom'`이므로, 여기에서 응답을 전달해야 합니다.
+    // `appType`이 `'custom'`이므로, 여기에서 응답을 제공해야 합니다.
     // 참고: `appType`이 `'spa'` 또는 `'mpa'`인 경우,
     // Vite는 HTML 요청과 404를 처리하는 미들웨어를 포함하므로
-    // Vite의 미들웨어가 적용되기 전에 사용자 미들웨어를 추가해야 합니다.
+    // 사용자 미들웨어가 효과를 내려면 Vite의 미들웨어보다 먼저 추가해야 합니다.
   })
 }
 
@@ -318,7 +341,7 @@ createServer()
 ## server.fs.strict {#server-fs-strict}
 
 - **타입:** `boolean`
-- **기본값:** `true` (Vite 2.7에서 기본적으로 활성화되도록 변경되었습니다.)
+- **기본값:** `true` (Vite 2.7부터 기본적으로 활성화되었습니다.)
 
 작업영역 루트 외부에 있는 파일 제공을 제한합니다.
 
@@ -326,7 +349,7 @@ createServer()
 
 - **타입:** `string[]`
 
-`/@fs/`를 통해 제공될 수 있는 파일을 제한합니다. `server.fs.strict`가 `true`로 설정된 경우, 이 목록에 포함되지 않았으며 허용된 파일에서 `import` 되는 것도 아닌 외부 파일에 접근하면 403 결과를 반환합니다.
+`/@fs/`를 통해 제공될 수 있는 파일을 제한합니다. `server.fs.strict`가 `true`로 설정된 경우, 이 디렉터리 목록 외부에 있고 허용된 파일에서 임포트되지도 않은 파일에 접근하면 403 결과를 반환합니다.
 
 디렉터리와 파일 모두 제공될 수 있습니다.
 
@@ -337,20 +360,20 @@ Vite는 잠재적인 작업 공간의 루트를 검색하여 기본값으로 사
   - `lerna.json`
   - `pnpm-workspace.yaml`
 
-커스텀 작업 공간 루트를 지정하는 경로를 허용합니다. 절대 경로 또는 [프로젝트 루트](/guide/#index-html-and-project-root)에 대한 상대 경로일 수 있습니다. 다음은 하나의 예입니다:
+커스텀 작업 공간 루트를 지정하는 경로를 받습니다. 절대 경로 또는 [프로젝트 루트](/guide/#index-html-and-project-root)에 대한 상대 경로일 수 있습니다. 예를 들어:
 
 ```js
 export default defineConfig({
   server: {
     fs: {
-      // 프로젝트 루트 바로 위 까지의 파일만 접근 가능
-      allow: ['..']
-    }
-  }
+      // 프로젝트 루트의 한 단계 위에서 파일을 제공하도록 허용
+      allow: ['..'],
+    },
+  },
 })
 ```
 
-만약 `server.fs.allow` 옵션이 지정되면, 자동으로 작업 영역의 루트를 감지하는 기능이 비활성화됩니다. 이후 기존의 동작을 확장하기 위해 `searchForWorkspaceRoot` 유틸리티가 노출됩니다:
+`server.fs.allow`가 지정되면, 자동 작업 공간 루트 감지는 비활성화됩니다. 기존 동작을 확장할 수 있도록 `searchForWorkspaceRoot` 유틸리티가 노출됩니다:
 
 ```js
 import { defineConfig, searchForWorkspaceRoot } from 'vite'
@@ -359,14 +382,14 @@ export default defineConfig({
   server: {
     fs: {
       allow: [
-        // 작업 공간(Workspace)의 루트를 지정
+        // 작업 공간 루트를 위쪽으로 검색
         searchForWorkspaceRoot(process.cwd()),
-        // 커스텀 allow 옵션 규칙
+        // 커스텀 규칙
         '/path/to/custom/allow_directory',
         '/path/to/custom/allow_file.demo',
-      ]
-    }
-  }
+      ],
+    },
+  },
 })
 ```
 
@@ -375,11 +398,17 @@ export default defineConfig({
 - **타입:** `string[]`
 - **기본값:** `['.env', '.env.*', '*.{crt,pem}', '**/.git/**']`
 
-Vite dev 서버에서 제공되지 않기를 원하는 민감한 파일들에 대한 차단 목록입니다. 이 옵션은 [`server.fs.allow`](#server-fs-allow)보다 높은 우선 순위를 가지며, [피코매치 패턴](https://github.com/micromatch/picomatch#globbing-features)을 사용할 수 있습니다.
+Vite 개발 서버가 제공하는 것을 제한할 민감한 파일에 대한 차단 목록입니다. 이 옵션은 [`server.fs.allow`](#server-fs-allow)보다 높은 우선 순위를 가집니다. [피코매치 패턴](https://github.com/micromatch/picomatch#globbing-features)이 지원됩니다.
 
 ::: tip 참고
 
-이 차단 목록은 [Public 디렉터리](/guide/assets.md#the-public-directory)에 적용되지 않습니다. Public 디렉터리 내 모든 파일은 빌드 시 결과물 출력 디렉터리에 직접 복사되며, 어떠한 필터링도 거치지 않습니다.
+이 차단 목록은 [Public 디렉터리](/guide/assets.md#the-public-directory)에 적용되지 않습니다. Public 디렉터리 내 모든 파일은 빌드 시 결과물 출력 디렉터리에 직접 복사되므로, 어떠한 필터링 없이 제공됩니다.
+
+:::
+
+::: tip 참고
+
+deny 필터는 모듈 id와 쿼리 매개변수가 제거된 id에 적용됩니다. 플러그인은 load 훅에서 어떤 파일이든 읽을 수 있으므로(차단된 경로로 확인되는 심볼릭 링크 포함), Vite는 차단된 파일이 대체 경로를 통해 접근 불가능하다고 보장할 수 없습니다. 대체 경로가 있다면 deny 목록에도 포함하세요.
 
 :::
 
@@ -387,13 +416,13 @@ Vite dev 서버에서 제공되지 않기를 원하는 민감한 파일들에 �
 
 - **타입:** `string`
 
-에셋 URL에 대한 `origin` 헤더를 정의합니다.
+개발 중 생성되는 에셋 URL의 origin을 정의합니다.
 
 ```js
 export default defineConfig({
   server: {
-    origin: 'http://127.0.0.1:8080/'
-  }
+    origin: 'http://127.0.0.1:8080',
+  },
 })
 ```
 
@@ -404,17 +433,17 @@ export default defineConfig({
 
 서버 소스맵에서 소스 파일을 무시할지 여부로, [`x_google_ignoreList` 소스 맵 확장](https://developer.chrome.com/articles/x-google-ignore-list/) 필드를 채워넣는 데 사용됩니다.
 
-`server.sourcemapIgnoreList`는 개발 서버에 대한 [`build.rollupOptions.output.sourcemapIgnoreList`](https://rollupjs.org/configuration-options/#output-sourcemapignorelist)와 동일합니다. 두 구성 옵션 사이의 차이점은 `sourcePath`에 대한 상대 경로로 rollup 함수가 호출되는 동안 `server.sourcemapIgnoreList`는 절대 경로로 호출된다는 것입니다. 개발 중에 대부분의 모듈은 맵과 소스가 동일한 폴더에 있으므로 `sourcePath`에 대한 상대 경로는 파일 이름 자체입니다. 이러한 경우 절대 경로를 사용하면 편리합니다.
+`server.sourcemapIgnoreList`는 개발 서버에 대한 [`build.rollupOptions.output.sourcemapIgnoreList`](https://rollupjs.org/configuration-options/#output-sourcemapignorelist)와 동일합니다. 두 구성 옵션 사이의 차이점은 Rollup 함수가 `sourcePath`에 대해 상대 경로로 호출되는 반면, `server.sourcemapIgnoreList`는 절대 경로로 호출된다는 것입니다. 개발 중에 대부분의 모듈은 맵과 소스가 동일한 폴더에 있으므로 `sourcePath`에 대한 상대 경로는 파일 이름 자체입니다. 이러한 경우 절대 경로를 사용하면 편리합니다.
 
-기본적으로 `node_modules`가 포함된 경로를 모두 제외합니다. 이 동작을 비활성화하려면 `false`를 전달하거나, 함수를 전달해 소스와 소스맵 경로를 받아 소스 경로를 무시할지 여부를 반환할 수 있습니다.
+기본적으로 `node_modules`가 포함된 모든 경로를 제외합니다. 이 동작을 비활성화하려면 `false`를 전달하거나, 완전한 제어를 위해 소스 경로와 소스맵 경로를 받아 소스 경로를 무시할지 여부를 반환하는 함수를 전달할 수 있습니다.
 
-```js twoslash
+```js
 export default defineConfig({
   server: {
-    // 이는 기본 값으로, node_modules가 경로에 포함된 모든 파일의 경로를
+    // 이는 기본값이며, 경로에 node_modules가 포함된 모든 파일을
     // 무시할 목록에 추가합니다.
     sourcemapIgnoreList(sourcePath, sourcemapPath) {
-      sourcePath.includes('node_modules')
+      return sourcePath.includes('node_modules')
     },
   },
 })

--- a/config/shared-options.md
+++ b/config/shared-options.md
@@ -17,11 +17,11 @@
 - **기본값:** `/`
 - **관련 항목:** [`server.origin`](/config/server-options.md#server-origin)
 
-개발 또는 프로덕션 모드에서 사용되는 Public Base Path 입니다. 유효한 값은 다음과 같습니다:
+개발 또는 프로덕션에서 제공될 때 사용되는 기본 public 경로입니다. 유효한 값은 다음과 같습니다:
 
 - 절대 URL 경로명, 예) `/foo/`
-- 전체 URL, 예) `https://bar.com/foo/` (URL Origin 부분은 사용되지 않으므로 `/foo/`와 같습니다.)
-- 빈 문자열 또는 `./`
+- 전체 URL, 예) `https://bar.com/foo/` (개발 중에는 origin 부분이 사용되지 않으므로 값은 `/foo/`와 같습니다.)
+- 빈 문자열 또는 `./` (임베디드 배포용)
 
 [Public Base Path](/guide/build#public-base-path)에서 더 자세한 점을 볼 수 있습니다.
 
@@ -40,7 +40,7 @@
 
 전역 상수로 대체되는 값을 정의합니다. 정의된 내용들은 개발 중에는 전역으로 정의되나, 빌드 중에는 정적으로 대체됩니다.
 
-Vite는 [esbuild defines](https://esbuild.github.io/api/#define)를 사용해 치환을 수행하므로, 값 표현식은 JSON 직렬화할 수 있는 값(null, boolean, number, string, array, 또는 object) 또는 단일 식별자인 문자열이어야 합니다. 만약 문자열이 아니라면, Vite는 `JSON.stringify`를 통해 자동으로 문자열로 변환합니다.
+Vite는 [Oxc의 define 기능](https://oxc.rs/docs/guide/usage/transformer/global-variable-replacement#define)을 사용해 치환을 수행하므로, 값 표현식은 JSON 직렬화할 수 있는 값(null, boolean, number, string, array, 또는 object)을 포함하는 문자열 또는 단일 식별자여야 합니다. 문자열이 아닌 값의 경우, Vite는 `JSON.stringify`를 통해 자동으로 문자열로 변환합니다.
 
 **예시:**
 
@@ -67,7 +67,7 @@ declare const __APP_VERSION__: string
 
 ## plugins {#plugins}
 
-- **타입:** ` (Plugin | Plugin[] | Promise<Plugin | Plugin[]>)[]`
+- **타입:** `(Plugin | Plugin[] | Promise<Plugin | Plugin[]>)[]`
 
 사용할 플러그인의 배열입니다. 잘못된 플러그인은 무시되고 플러그인의 배열은 평탄화됩니다. 만약 프로미스 객체가 반환된다면, 실행되기 전 해당 데이터를 모두 가져옵니다. [플러그인 API](/guide/api-plugin)에서 Vite 플러그인에 대한 더 자세한 점을 볼 수 있습니다.
 
@@ -87,22 +87,56 @@ declare const __APP_VERSION__: string
 - **타입:** `string`
 - **기본값:** `"node_modules/.vite"`
 
-캐시 파일을 저장할 디렉터리 입니다. 이 디렉터리의 파일들은 미리 번들된 의존 파일이거나 Vite에 의해 생성된 어떤 다른 캐시 파일로서, 성능을 향상시킬 수 있습니다. 캐시 파일을 다시 생성하기 위해 `--force` 플래그를 사용하거나 또는 직접 디렉터리를 삭제할 수 있습니다. 값은 절대 파일 시스템 경로 또는 프로젝트 루트의 상대적인 경로중 하나가 될 수 있습니다.
+캐시 파일을 저장할 디렉터리 입니다. 이 디렉터리의 파일들은 미리 번들된 디펜던시이거나 Vite에 의해 생성된 다른 캐시 파일로서, 성능을 향상시킬 수 있습니다. 캐시 파일을 다시 생성하기 위해 `--force` 플래그를 사용하거나 직접 디렉터리를 삭제할 수 있습니다. 값은 절대 파일 시스템 경로 또는 프로젝트 루트의 상대적인 경로중 하나가 될 수 있습니다. `package.json`이 감지되지 않으면 기본값은 `.vite`입니다.
 
 ## resolve.alias {#resolve-alias}
 
 - **타입:**
-`Record<string, string> | Array<{ find: string | RegExp, replacement: string, customResolver?: ResolverFunction | ResolverObject }>`
+  `Record<string, string> | Array<{ find: string | RegExp, replacement: string }>`
 
-이 옵션의 값은 `@rollup/plugin-alias` 의 [entries 옵션](https://github.com/rollup/plugins/tree/master/packages/alias#entries)으로 전달됩니다. 객체나 `{ find, replacement, customResolver }` 페어 배열이 될 수 있습니다.
+`import` 또는 `require` 문에서 값을 대체하는 데 사용되는 별칭을 정의합니다. 이는 [`@rollup/plugin-alias`](https://github.com/rollup/plugins/tree/master/packages/alias)와 유사하게 동작합니다.
+
+엔트리의 순서는 중요하며, 먼저 정의된 규칙이 먼저 적용됩니다.
 
 파일 시스템 경로에 별칭을 만들 때에는, 반드시 절대 경로를 사용하세요. 상대 경로 별칭은 있는 그대로 사용되며, 파일 시스템 경로로 적절하게 해석되지 않습니다.
 
-더 자세한 해결책은 [플러그인](/guide/api-plugin)에서 찾아볼 수 있습니다.
+더 자세한 커스텀 해석은 [플러그인](/guide/api-plugin)을 통해 구현할 수 있습니다.
 
 ::: warning SSR 사용 시 주의사항
 [SSR 외부화된 디펜던시](/guide/ssr.md#ssr-externals)를 위해 별칭을 사용했다면, 기존의 실제 `node_modules` 패키지도 별칭으로 설정하는 것이 좋습니다. [Yarn](https://classic.yarnpkg.com/en/docs/cli/add/#toc-yarn-add-alias)과 [pnpm](https://pnpm.io/aliases/) 모두 `npm:` 접두사를 통해 별칭을 지원합니다.
 :::
+
+### 객체 형식 (`Record<string, string>`) {#object-format-record-string-string}
+
+객체 형식은 별칭을 키로 지정하고, 대응하는 값을 실제 import 값으로 지정할 수 있게 합니다. 예를 들면 다음과 같습니다:
+
+```js
+resolve: {
+  alias: {
+    utils: '../../../utils',
+    'batman-1.0.0': './joker-1.5.0'
+  }
+}
+```
+
+### 배열 형식 (`Array<{ find: string | RegExp, replacement: string }>`) {#array-format-array-find-string-regexp-replacement-string}
+
+배열 형식은 별칭을 객체로 지정할 수 있게 하며, 복잡한 key/value 쌍에 유용할 수 있습니다.
+
+```js
+resolve: {
+  alias: [
+    { find: 'utils', replacement: '../../../utils' },
+    { find: 'batman-1.0.0', replacement: './joker-1.5.0' },
+  ]
+}
+```
+
+`find`가 정규식인 경우, `replacement`는 `$1`과 같은 [replacement patterns](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement)을 사용할 수 있습니다. 예를 들어 확장자를 다른 것으로 제거하려면 다음과 같은 패턴을 사용할 수 있습니다:
+
+```js
+{ find:/^(.*)\.js$/, replacement: '$1.alias' }
+```
 
 ## resolve.dedupe {#resolve-dedupe}
 
@@ -114,7 +148,7 @@ declare const __APP_VERSION__: string
 SSR 빌드의 경우, `build.rollupOptions.output`을 통해 구성된 ESM 빌드 결과물에 대해 중복된 코드의 제거가 진행되지 않습니다. 이를 해결하기 위해서는 ESM이 모듈 로드에 대한 플러그인 지원을 개선할 때까지 CJS(CommonJS) 빌드를 이용하는 것입니다.
 :::
 
-## resolve.conditions <NonInheritBadge />
+## resolve.conditions <NonInheritBadge /> {#resolve-conditions-noninheritbadge}
 
 - **타입:** `string[]`
 - **기본값:** `['module', 'browser', 'development|production']` (`defaultClientConditions`)
@@ -140,10 +174,12 @@ SSR 빌드의 경우, `build.rollupOptions.output`을 통해 구성된 ESM 빌�
 
 참고로 `import`, `require`, `default` 조건은 요구사항이 충족되면 항상 적용됩니다.
 
-## resolve.mainFields <NonInheritBadge />
+또한 `@import 'my-library'`와 같이 스타일 임포트를 해석할 때는 `style` 조건이 적용됩니다. 일부 CSS 전처리기의 경우, 해당하는 조건도 함께 적용됩니다. 즉 Sass에는 `sass`, Less에는 `less`가 적용됩니다.
+
+## resolve.mainFields <NonInheritBadge /> {#resolve-mainfields-noninheritbadge}
 
 - **타입:** `string[]`
-- **기본값:** `['browser', 'module', 'jsnext:main', 'jsnext']` (`defaultClientConditions`)
+- **기본값:** `['browser', 'module', 'jsnext:main', 'jsnext']` (`defaultClientMainFields`)
 
 패키지의 진입점을 확인할 때 시도할 `package.json`안의 필드 목록입니다. 이것은 `exports` 필드에서 처리되는 조건부 내보내기보다 우선순위가 낮습니다: 만약 진입점이 `exports`로부터 성공적으로 확인되면, 메인 필드는 무시될 것입니다.
 
@@ -163,6 +199,13 @@ SSR 빌드의 경우, `build.rollupOptions.output`을 통해 구성된 ESM 빌�
 
 - **관련 항목:** [esbuild#preserve-symlinks](https://esbuild.github.io/api/#preserve-symlinks), [webpack#resolve.symlinks
   ](https://webpack.js.org/configuration/resolve/#resolvesymlinks)
+
+## resolve.tsconfigPaths {#resolve-tsconfigpaths}
+
+- **타입:** `boolean`
+- **기본값:** `false`
+
+tsconfig paths 해석 기능을 활성화합니다. `tsconfig.json`의 `paths` 옵션이 임포트를 해석하는 데 사용됩니다. 자세한 내용은 [기능](/guide/features.md#paths)을 참고하세요.
 
 ## html.cspNonce {#html-cspnonce}
 
@@ -276,6 +319,10 @@ export default defineConfig({
 })
 ```
 
+::: tip 파일 임포트하기
+동일한 코드가 서로 다른 디렉터리의 파일 앞에 추가되므로, 상대 경로는 올바르게 해석되지 않습니다. 대신 절대 경로나 [별칭](#resolve-alias)을 사용하세요.
+:::
+
 ## css.preprocessorMaxWorkers {#css-preprocessormaxworkers}
 
 - **타입:** `number | true`
@@ -291,7 +338,7 @@ CSS 전처리기가 사용할 수 있는 최대 스레드 수를 지정합니다
 - **타입:** `boolean`
 - **기본값:** `false`
 
-개발 중 CSS 소스 맵을 활성화할지 여부를 나타냅니다.
+개발 중 소스 맵을 활성화할지 여부를 나타냅니다.
 
 ## css.transformer {#css-transformer}
 
@@ -353,47 +400,55 @@ Lightning CSS 옵션입니다. 전체 변환 옵션은 [Lightning CSS 리포지�
 
 `'auto'`로 설정한다면, [데이터가 10kB보다 큰 경우에만](https://v8.dev/blog/cost-of-javascript-2019#json:~:text=A%20good%20rule%20of%20thumb%20is%20to%20apply%20this%20technique%20for%20objects%20of%2010%20kB%20or%20larger) 문자열화됩니다.
 
+## oxc {#oxc}
+
+- **타입:** `OxcOptions | false`
+
+`OxcOptions`는 [Oxc Transformer 옵션](https://oxc.rs/docs/guide/usage/transformer)을 확장합니다. 가장 일반적인 사례는 JSX를 커스터마이즈하는 것입니다:
+
+```js
+export default defineConfig({
+  oxc: {
+    jsx: {
+      runtime: 'classic',
+      pragma: 'h',
+      pragmaFrag: 'Fragment',
+    },
+  },
+})
+```
+
+기본적으로 Oxc에 의한 변환은 `ts`, `jsx`, `tsx` 파일들에 적용됩니다. `oxc.include`와 `oxc.exclude`를 사용하여 커스터마이즈할 수 있으며, 정규식이나 [picomatch](https://github.com/micromatch/picomatch#globbing-features) 패턴 또는 그 중 하나의 배열이 될 수 있습니다.
+
+추가적으로, Oxc에 의해 변환된 모든 파일에 대해 JSX 헬퍼 import를 자동으로 주입하기 위해 `oxc.jsxInject`도 사용할 수 있습니다:
+
+```js
+export default defineConfig({
+  oxc: {
+    jsxInject: `import React from 'react'`,
+  },
+})
+```
+
+Oxc에 의한 변환을 비활성화하려면 `false`로 설정하세요.
+
 ## esbuild {#esbuild}
 
 - **타입:** `ESBuildOptions | false`
+- **지원 중단됨**
 
-`ESBuildOptions`는 [esbuild 변환 옵션](https://esbuild.github.io/api/#transform)을 확장합니다. 가장 일반적인 사례는 JSX를 커스터마이즈하는 것입니다:
-
-```js
-export default defineConfig({
-  esbuild: {
-    jsxFactory: 'h',
-    jsxFragment: 'Fragment'
-  }
-})
-```
-
-기본적으로, ESBuild는 `ts`, `jsx`, `tsx` 파일들에 적용됩니다. `esbuild.include`와 `esbuild.exclude`를 사용하여 커스터마이즈할 수 있으며, 정규식이나 [picomatch](https://github.com/micromatch/picomatch#globbing-features) 패턴 또는 그 중 하나의 배열이 될 수 있습니다.
-
-추가적으로, ESBuild에 의해 변환된 모든 파일에 대해 JSX 헬퍼 `import` 들을 자동으로 주입하기 위해 `esbuild.jsxInject`도 사용할 수 있습니다:
-
-```js
-export default defineConfig({
-  esbuild: {
-    jsxInject: `import React from 'react'`
-  }
-})
-```
-
-[`build.minify`](./build-options.md#build-minify)가 `true`인 경우, 기본적으로 모든 축소(Minify) 최적화가 적용됩니다. 코드의 [일부분](https://esbuild.github.io/api/#minify)만 이를 적용하지 않기 위해서는 `esbuild.minifyIdentifiers`, `esbuild.minifySyntax`, 또는 `esbuild.minifyWhitespace` 옵션을 `false`로 설정해주세요. 참고로 `esbuild.minify` 옵션은 `build.minify`를 재정의하는 데 사용할 수 없습니다.
-
-esbuild 변환을 사용하지 않으려면 `false`로 설정하세요.
+이 옵션은 내부적으로 `oxc` 옵션으로 변환됩니다. 대신 `oxc` 옵션을 사용하세요.
 
 ## assetsInclude {#assetsinclude}
 
 - **타입:** `string | RegExp | (string | RegExp)[]`
 - **관련 항목:** [정적 에셋 가져오기](/guide/assets)
 
-정적 에셋으로 처리할 추가 [picomatch 패턴](https://github.com/micromatch/picomatch#globbing-features)을 지정합니다:
+다음 조건을 만족하도록 정적 에셋으로 처리할 추가 [picomatch 패턴](https://github.com/micromatch/picomatch#globbing-features)을 지정합니다:
 
-- HTML에서 참조되거나 `fetch` 또는 XHR을 통해 직접 요청될 때, 이것은 플러그인 변환 파이프라인에서 제외됩니다.
+- HTML에서 참조되거나 `fetch` 또는 XHR을 통해 직접 요청될 때, 플러그인 변환 파이프라인에서 제외됩니다.
 
-- JS에서 그것을 가져오면 처리된 URL 문자열이 반환됩니다. (이것은 에셋 형식을 다르게 처리하기 위한 `enforce: 'pre'` 플러그인이 있다면 덮어 쓰일 수 있습니다.)
+- JS에서 임포트하면 해석된 URL 문자열이 반환됩니다. (에셋 형식을 다르게 처리하기 위한 `enforce: 'pre'` 플러그인이 있다면 덮어쓸 수 있습니다.)
 
 이 빌트인 에셋 형식 목록은 [여기](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/constants.ts)에서 확인할 수 있습니다.
 
@@ -401,7 +456,7 @@ esbuild 변환을 사용하지 않으려면 `false`로 설정하세요.
 
 ```js
 export default defineConfig({
-  assetsInclude: ['**/*.gltf']
+  assetsInclude: ['**/*.gltf'],
 })
 ```
 
@@ -428,7 +483,7 @@ export default defineConfig({
 
 커스텀 로거를 사용하여 메시지를 로그로 남깁니다. `createLogger` API를 사용해 Vite의 로거를 가져와 메시지를 변경하거나 특정 경고를 필터링하는 등의 작업을 수행할 수 있습니다.
 
-```js twoslash
+```ts twoslash
 import { createLogger, defineConfig } from 'vite'
 
 const logger = createLogger()
@@ -488,11 +543,22 @@ define: {
 
 애플리케이션이 단일 페이지 애플리케이션(SPA), [다중 페이지 애플리케이션(MPA)](../guide/build#multi-page-app), 또는 커스텀 애플리케이션(SSR 및 커스텀 HTML 처리를 하는 프레임워크)인지 여부:
 
-- `'spa'`: HTML 미들웨어와 SPA 폴백(Fallback)을 사용합니다. 프리뷰 모드에서 `single: true`로 [sirv](https://github.com/lukeed/sirv)를 설정합니다.
+- `'spa'`: HTML 미들웨어를 포함하고 SPA 폴백(Fallback)을 사용합니다. 프리뷰에서 `single: true`로 [sirv](https://github.com/lukeed/sirv)를 설정합니다.
 - `'mpa'`: HTML 미들웨어를 포함합니다.
 - `'custom'`: HTML 미들웨어를 포함하지 않습니다.
 
-더 많은 정보가 필요하다면 Vite의 [SSR 가이드](/guide/ssr#vite-cli)를 참고해주세요. [`server.middlewareMode`](./server-options#server-middlewaremode) 옵션도 참고가 가능합니다.
+더 많은 정보가 필요하다면 Vite의 [SSR 가이드](/guide/ssr#vite-cli)를 참고해주세요. 관련 항목: [`server.middlewareMode`](./server-options#server-middlewaremode).
+
+## devtools {#devtools}
+
+- **실험적 기능:** [이 곳에 피드백을 남겨주세요](https://github.com/vitejs/devtools/discussions)
+- **타입:** `boolean` | `DevToolsConfig`
+- **기본값:** `false`
+
+내부 상태와 빌드 분석을 시각화하기 위한 devtools 통합을 활성화합니다.
+`@vitejs/devtools`가 디펜던시로 설치되어 있는지 확인하세요. 이 기능은 현재 빌드 모드에서만 지원됩니다.
+
+자세한 내용은 [Vite DevTools](https://github.com/vitejs/devtools)를 참고하세요.
 
 ## future {#future}
 

--- a/config/worker-options.md
+++ b/config/worker-options.md
@@ -14,10 +14,17 @@
 - **타입:** [`() => (Plugin | Plugin[])[]`](./shared-options#plugins)
 
 워커 번들에 적용되는 Vite 플러그인입니다. [config.plugins](./shared-options#plugins)은 개발 모드에서만 워커에 적용되며, 빌드 시에는 여기에 설정해야 합니다.
-함수는 병렬 Rollup 워커 빌드에서 사용되는 새로운 플러그인 인스턴스를 반환해야 합니다. 따라서 `config` 훅에서 `config.worker` 옵션을 수정하는 것은 무시됩니다.
+함수는 병렬 rolldown 워커 빌드에서 사용되는 새로운 플러그인 인스턴스를 반환해야 합니다. 따라서 `config.worker` 옵션을 수정하는 것은 `config` 훅에서 무시됩니다.
+
+## worker.rolldownOptions {#worker-rolldownoptions}
+
+- **타입:** [`RolldownOptions`](https://rolldown.rs/reference/)
+
+워커 번들 빌드 시 Rolldown 옵션입니다.
 
 ## worker.rollupOptions {#worker-rollupoptions}
 
-- **타입:** [`RollupOptions`](https://rollupjs.org/configuration-options/)
+- **타입:** `RolldownOptions`
+- **지원 중단됨**
 
-워커 번들 빌드 시 Rollup 옵션입니다.
+이 옵션은 `worker.rolldownOptions` 옵션의 별칭입니다. 대신 `worker.rolldownOptions` 옵션을 사용하세요.


### PR DESCRIPTION
## Summary
PR #1366 의 `config` 섹션 번역 (6/7).

### ⚠️ Manual translation 필요
- `config/index.md` — codex output truncation. 별도 처리.

### Resolved
Resolved #1563
Resolved #1562
Resolved #1551
Resolved #1542
Resolved #1533
Resolved #1500
Resolved #1473
Resolved #1461
Resolved #1448
Resolved #1447
Resolved #1431
Resolved #1424
Resolved #1412
Resolved #1411
Resolved #1360
Resolved #1359
Resolved #1357

### Refs (multi-section)
Refs #1548
Refs #1518
Refs #1509
Refs #1491
Refs #1487
Refs #1480
Refs #1478
Refs #1475
Refs #1474
Refs #1462
Refs #1423
Refs #1407
Refs #1394
Refs #1393
Refs #1392

## Test plan
- [x] pnpm build 통과
- [x] prettier 통과
- [ ] reviewer spot-check
- [ ] nara-speller
- [ ] config/index.md manual 번역 후 ready